### PR TITLE
Add config file support to project create command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+.venv/
 .env
 .venv-ide
 .venv-sync

--- a/src/claudesync/cli/project.py
+++ b/src/claudesync/cli/project.py
@@ -77,17 +77,6 @@ def create(ctx, config_file, name, internal_name, description, organization, no_
 
     2. Using a config file:
        claudesync project create --config-file project-config.json
-
-    The config file should be a JSON file with the following structure:
-    {
-        "project_name": "Project Name",
-        "internal_name": "project-name",
-        "project_description": "Project description",  // Optional
-        "includes": [],  // Optional
-        "excludes": [],     // Optional
-        "use_ignore_files": true,  // Optional
-        "push_roots": []    // Optional
-    }
     """
     config = ctx.obj
     provider_instance = get_provider(config)

--- a/src/claudesync/cli/project.py
+++ b/src/claudesync/cli/project.py
@@ -81,9 +81,9 @@ def create(ctx, config_file, name, internal_name, description, organization, no_
     The config file should be a JSON file with the following structure:
     {
         "project_name": "Project Name",
-        "internal_name": "project-name",  // Optional, defaults to 'all' for first project
-        "project_description": "Project description",
-        "includes": ["*"],  // Optional
+        "internal_name": "project-name",
+        "project_description": "Project description",  // Optional
+        "includes": [],  // Optional
         "excludes": [],     // Optional
         "use_ignore_files": true,  // Optional
         "push_roots": []    // Optional
@@ -100,13 +100,12 @@ def create(ctx, config_file, name, internal_name, description, organization, no_
 
             # Extract required fields
             name = file_config.get('project_name')
-            description = file_config.get('project_description')
+            internal_name = file_config.get('internal_name')
+            # Description is optional, default to standard description if not provided
+            description = file_config.get('project_description', "Project created with ClaudeSync")
 
-            if not all([name, description]):
-                raise ConfigurationError("Config file must contain 'project_name' and 'project_description' fields")
-
-            # Use provided internal_name or get default
-            internal_name = file_config.get('internal_name') or get_default_internal_name()
+            if not all([name, internal_name]):
+                raise ConfigurationError("Config file must contain 'project_name' and 'internal_name' fields")
 
         except json.JSONDecodeError as e:
             raise ConfigurationError(f"Invalid JSON in config file: {str(e)}")


### PR DESCRIPTION
**Changes**

- Added support for creating projects using a JSON configuration file
- Made the project create command work in two modes:
  - Interactive mode (existing behavior)
  - Config file mode (new feature)
- Updated project validation logic for required/optional fields

**Testing Guidelines**

1. Interactive Mode (Existing)
Verify the existing interactive mode still works: `claudesync project create`
2. Config File Mode (New)
Test creating projects with various config file configurations: 
`claudesync project create --config-file .claudesync/fullstack-app.project.json`
