### PR TITLE
Referenced Projects Support

### DIFF
--- a/src/claudesync/web/src/app/treemap.component.html
+++ b/src/claudesync/web/src/app/treemap.component.html
@@ -63,6 +63,7 @@
             <th>Path</th>
             <th>File Name</th>
             <th>Size</th>
+            <th>Source</th>
             <th>Status</th>
             <th></th>
           </tr>
@@ -72,6 +73,7 @@
             <td>{{ file.path || '/' }}</td>
             <td>{{ file.name }}</td>
             <td>{{ formatSize(file.size) }}</td>
+            <td>{{ file.source }}</td>
             <td [class.included]="file.included">
               {{ file.included ? 'Included' : 'Excluded' }}
             </td>

--- a/src/claudesync/web/src/app/treemap.types.ts
+++ b/src/claudesync/web/src/app/treemap.types.ts
@@ -19,6 +19,7 @@ export interface FileInfo {
   fullPath: string; // Complete path including file name
   size: number;
   included: boolean;
+  source?: string;  // Source of the file (main project or referenced project)
 }
 
 export interface SelectedNode {


### PR DESCRIPTION
This PR adds support for including files from referenced projects in Claude.ai synchronization. This feature allows projects to include and sync files from other ClaudeSync-managed projects, enabling better code reuse and modular project organization.

**Core Features**

- Projects can reference other ClaudeSync projects using unique reference IDs
- Files from referenced projects are synchronized alongside main project files
- Referenced files maintain their original paths and structures
- Supports selective inclusion/exclusion patterns per referenced project
- Security measures prevent path traversal and unauthorized access
- ❗Partially working visualization support in simulation UI. Shows only Included Files

**Configuration Structure**

Projects can specify references in their project configuration:

```
{
  "references": ["shared-lib", "utils"],
  "includes": ["*"],
  "excludes": []
}
```

Reference paths are stored separately in project_id.json:

```
{
  "project_id": "uuid",
  "reference_paths": {
    "shared-lib": "/path/to/shared-lib/.claudesync/config.json",
    "utils": "/path/to/utils/.claudesync/config.json"
  }
}
```

**Usage Example**
```
# Two options to list matching files from main and referenced projects

claudesync simulate-push --list

claudesync push --dry-run

# Added support for references in the project files
# Basic project with references

claudesync project create --references shared-lib,utils --reference-paths '{"shared-lib":"/path/to/shared/.claudesync/config.json","utils":"/path/to/utils/.claudesync/config.json"}'

# Using a template with references

claudesync project create --template mytemplate --references shared-lib
```

